### PR TITLE
Workaround to fix arrow keys on non-conhost Windows terminals

### DIFF
--- a/libs/pdcurses-3.4/win32/pdckbd.c
+++ b/libs/pdcurses-3.4/win32/pdckbd.c
@@ -404,6 +404,14 @@ static int _process_key_event(void)
         }
 	case VK_BACK:
 		return KEY_BACKSPACE;
+    case VK_DOWN:
+        return KEY_DOWN;
+    case VK_UP:
+        return KEY_UP;
+    case VK_LEFT:
+        return KEY_LEFT;
+    case VK_RIGHT:
+        return KEY_RIGHT;
     }
 
     /* The system may emit Ascii or Unicode characters depending on


### PR DESCRIPTION
The traditional conhost.exe terminal on Windows seems to treat arrow keys differently from other terminals, which is not accounted for in PDCurses. This adds some virtual key translations to make arrow keys work in non-conhost terminals like VSCode or Windows Terminal Preview.